### PR TITLE
Run GitHub Actions on All Branches

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -2,7 +2,6 @@ name: Nightly
 
 on:
     push:
-        branches: [main]
         paths:
             - "src/**"
             - "scripts/**"


### PR DESCRIPTION
Simply removes rules for what branches to run on.

TODO: Eventually get around to making it run for pull requests with a certain label as well?